### PR TITLE
Make sure that no file were uploaded in threads

### DIFF
--- a/src/posting.go
+++ b/src/posting.go
@@ -887,7 +887,7 @@ func makePost(w http.ResponseWriter, r *http.Request, data interface{}) {
 			file.Close()
 		}
 	}()
-	if err != nil {
+	if err != nil || handler.Size == 0 {
 		// no file was uploaded
 		post.Filename = ""
 		accessLog.Print("Receiving post from " + request.RemoteAddr + ", referred from: " + request.Referer())


### PR DESCRIPTION
This change checks the filesize to make sure that the POST request to create new threads/posts contains no files.